### PR TITLE
Test jaxpm forward modeling on flip

### DIFF
--- a/flip/simulation/__init__.py
+++ b/flip/simulation/__init__.py
@@ -1,0 +1,120 @@
+"""flip.simulation — JAX-differentiable forward modeling via JaxPM.
+
+End-to-end pipeline for field-level inference of cosmological parameters
+(in particular fσ₈) from peculiar velocity and density surveys.
+
+Pipeline overview::
+
+    cosmological params (omega_m, sigma8, …)
+            │
+            ▼
+    get_cosmology() → jax_cosmo.Cosmology
+            │
+            ▼
+    ForwardModel.get_fields(cosmo, seed)
+      ├─ _differentiable_linear_field()   ← DC-mode-safe Gaussian IC
+      ├─ _run_lpt()                        ← manual 1LPT (grad-safe)
+      └─ [run_pm()]                        ← optional PM time-stepping
+            │
+     ┌──────┴──────┐
+     ▼             ▼
+ density_field  velocity_field  (on 3D mesh)
+     │             │
+     ▼             ▼
+ interpolate_density_to_positions()
+ interpolate_velocity_to_positions()
+ compute_los_velocity()
+     │
+     ▼
+ VelocityFieldLikelihood(cosmo_params) → -log L
+     │
+     ▼
+ SimulationFitter.run() → best-fit params
+
+Submodules
+----------
+generator
+    :class:`ForwardModel` — DC-mode-safe IC + manual 1LPT + optional PM.
+    :func:`get_cosmology` — build ``jax_cosmo.Cosmology``.
+cosmo_utils
+    Adapters between flip parameter dicts and ``jax_cosmo`` objects;
+    P(k) callable construction from tabulated arrays.
+painter
+    CIC interpolation, LOS velocity projection, sky↔Cartesian conversion, RSD.
+likelihood
+    :class:`VelocityFieldLikelihood`, :func:`log_likelihood_gaussian`.
+fitter
+    :class:`SimulationFitter` — gradient-based optimization via ``jaxopt``.
+
+Optional dependencies
+---------------------
+* ``jaxpm`` — particle mesh N-body (required for simulations).
+* ``jax_cosmo`` — JAX cosmology (required for unit conversions).
+* ``jaxopt`` — required for :class:`~flip.simulation.fitter.SimulationFitter`.
+All are optional at import time; errors are raised at first use.
+"""
+
+# cosmo_utils has only numpy/scipy dependencies — always importable
+from .cosmo_utils import (
+    cosmo_with_sigma8_from_fs8,
+    flip_params_to_jaxcosmo,
+    make_pk_callable,
+    make_pk_callable_from_dict,
+    sigma8_from_fs8,
+)
+
+# painter only needs jax.numpy — fails gracefully without JAX
+from .painter import (
+    _cic_read,
+    apply_rsd,
+    cartesian_to_box_frame,
+    compute_los_velocity,
+    interpolate_density_to_positions,
+    interpolate_velocity_to_positions,
+    sky_to_cartesian,
+)
+
+# generator and likelihood/fitter require jaxpm + jax_cosmo — lazy-load
+_LAZY = {
+    "ForwardModel", "get_cosmology", "_differentiable_linear_field", "_run_lpt",
+    "VelocityFieldLikelihood", "log_likelihood_gaussian",
+    "SimulationFitter",
+}
+
+
+def __getattr__(name):
+    if name in ("ForwardModel", "get_cosmology", "_differentiable_linear_field", "_run_lpt"):
+        from .generator import ForwardModel, get_cosmology, _differentiable_linear_field, _run_lpt
+        globals().update({
+            "ForwardModel": ForwardModel, "get_cosmology": get_cosmology,
+            "_differentiable_linear_field": _differentiable_linear_field,
+            "_run_lpt": _run_lpt,
+        })
+        return globals()[name]
+    if name in ("VelocityFieldLikelihood", "log_likelihood_gaussian"):
+        from .likelihood import VelocityFieldLikelihood, log_likelihood_gaussian
+        globals().update({
+            "VelocityFieldLikelihood": VelocityFieldLikelihood,
+            "log_likelihood_gaussian": log_likelihood_gaussian,
+        })
+        return globals()[name]
+    if name == "SimulationFitter":
+        from .fitter import SimulationFitter
+        globals()["SimulationFitter"] = SimulationFitter
+        return SimulationFitter
+    raise AttributeError(f"module 'flip.simulation' has no attribute {name!r}")
+
+
+__all__ = [
+    # cosmo_utils
+    "flip_params_to_jaxcosmo", "sigma8_from_fs8", "cosmo_with_sigma8_from_fs8",
+    "make_pk_callable", "make_pk_callable_from_dict",
+    # painter
+    "_cic_read", "compute_los_velocity", "interpolate_velocity_to_positions",
+    "interpolate_density_to_positions", "sky_to_cartesian",
+    "cartesian_to_box_frame", "apply_rsd",
+    # lazy
+    "get_cosmology", "ForwardModel", "_differentiable_linear_field", "_run_lpt",
+    "log_likelihood_gaussian", "VelocityFieldLikelihood",
+    "SimulationFitter",
+]

--- a/flip/simulation/cosmo_utils.py
+++ b/flip/simulation/cosmo_utils.py
@@ -1,0 +1,183 @@
+"""Utilities for bridging flip parameter dicts and jax_cosmo Cosmology objects.
+
+Flip's inference parameters (fs8, bs8, sigv, …) are not the same as the full
+cosmological set required by JaxPM/jax_cosmo. This module handles:
+  - converting a flip parameter dict + fixed background cosmology → jax_cosmo.Cosmology
+  - decomposing fs8 into f and σ₈ given a cosmological background
+  - building JAX-compatible P(k) callables from tabulated arrays
+"""
+
+try:
+    import jax.numpy as jnp
+    import jax_cosmo as jc
+    from jax_cosmo import background
+
+    jaxcosmo_installed = True
+except ImportError:
+    import numpy as jnp
+
+    jaxcosmo_installed = False
+
+
+def flip_params_to_jaxcosmo(params_dict, base_cosmo_dict):
+    """Build a jax_cosmo Cosmology from flip inference parameters + fixed background.
+
+    Flip typically infers fs8, bs8, sigv (and optionally sigma8, H_0) while
+    keeping the background cosmology fixed. This function merges the two,
+    letting entries in ``params_dict`` override ``base_cosmo_dict``.
+
+    ``base_cosmo_dict`` should use jax_cosmo key names (Omega_c, not Omega_m).
+    If ``Omega_m`` is present and ``Omega_c`` is absent, the conversion
+    ``Omega_c = Omega_m - Omega_b`` is applied automatically.
+
+    Args:
+        params_dict (dict): Flip inference parameters, e.g.
+            ``{"fs8": 0.4, "sigma8": 0.8, "H_0": 67.0}``.
+        base_cosmo_dict (dict): Fixed background cosmology with keys taken
+            from ``{Omega_c, Omega_b, h, sigma8, n_s, w0, wa, Omega_k}``.
+
+    Returns:
+        jax_cosmo.Cosmology: Cosmology object ready for JaxPM.
+
+    Raises:
+        ImportError: If jax_cosmo is not installed.
+    """
+    if not jaxcosmo_installed:
+        raise ImportError(
+            "jax_cosmo is required for forward modeling. "
+            "Install with: pip install jax-cosmo"
+        )
+
+    cosmo_dict = dict(base_cosmo_dict)
+
+    # H_0 [km/s/Mpc] → h
+    if "H_0" in params_dict:
+        cosmo_dict["h"] = params_dict["H_0"] / 100.0
+
+    # Override cosmological parameters when present in flip params
+    for key in ("sigma8", "Omega_c", "Omega_b", "h", "n_s", "w0", "wa", "Omega_k"):
+        if key in params_dict:
+            cosmo_dict[key] = params_dict[key]
+
+    # Omega_m → Omega_c (jax_cosmo convention)
+    if "Omega_m" in cosmo_dict and "Omega_c" not in cosmo_dict:
+        Omega_b = cosmo_dict.get("Omega_b", 0.0)
+        cosmo_dict["Omega_c"] = cosmo_dict.pop("Omega_m") - Omega_b
+
+    return jc.Cosmology(
+        Omega_c=float(cosmo_dict.get("Omega_c", 0.25)),
+        Omega_b=float(cosmo_dict.get("Omega_b", 0.05)),
+        h=float(cosmo_dict.get("h", 0.67)),
+        sigma8=float(cosmo_dict.get("sigma8", 0.8)),
+        n_s=float(cosmo_dict.get("n_s", 0.96)),
+        w0=float(cosmo_dict.get("w0", -1.0)),
+        wa=float(cosmo_dict.get("wa", 0.0)),
+        Omega_k=float(cosmo_dict.get("Omega_k", 0.0)),
+    )
+
+
+def sigma8_from_fs8(fs8, cosmo, a):
+    """Infer σ₈ from fs8 = f(a) · σ₈ and the linear growth rate f(a).
+
+    Useful when the forward model needs σ₈ (to set the amplitude of P(k))
+    but the inference parameter is fs8.
+
+    Args:
+        fs8 (float): Growth rate × σ₈ (flip's primary velocity parameter).
+        cosmo (jax_cosmo.Cosmology): Background cosmology (used for f(a)).
+        a (float): Scale factor at which the decomposition is made.
+
+    Returns:
+        float: σ₈ = fs8 / f(a).
+
+    Raises:
+        ImportError: If jax_cosmo is not installed.
+    """
+    if not jaxcosmo_installed:
+        raise ImportError("jax_cosmo is required.")
+
+    f = background.growth_rate(cosmo, jnp.atleast_1d(a))[0]
+    return fs8 / f
+
+
+def cosmo_with_sigma8_from_fs8(fs8, cosmo, a):
+    """Return a copy of cosmo with σ₈ replaced by σ₈ = fs8 / f(a).
+
+    This is the typical call sequence when the inference parameter is fs8
+    and the power spectrum needs a consistent σ₈.
+
+    Args:
+        fs8 (float): Growth rate × σ₈.
+        cosmo (jax_cosmo.Cosmology): Base cosmology.
+        a (float): Scale factor.
+
+    Returns:
+        jax_cosmo.Cosmology: New cosmology with updated sigma8.
+    """
+    if not jaxcosmo_installed:
+        raise ImportError("jax_cosmo is required.")
+
+    sigma8 = sigma8_from_fs8(fs8, cosmo, a)
+    return jc.Cosmology(
+        Omega_c=cosmo.Omega_c,
+        Omega_b=cosmo.Omega_b,
+        h=cosmo.h,
+        sigma8=sigma8,
+        n_s=cosmo.n_s,
+        w0=cosmo.w0,
+        wa=cosmo.wa,
+        Omega_k=cosmo.Omega_k,
+    )
+
+
+def make_pk_callable(k_arr, pk_arr):
+    """Build a JAX-differentiable P(k) callable from tabulated arrays.
+
+    Uses log-log linear interpolation (power-law between nodes), which is
+    both accurate for CDM power spectra and fully differentiable via
+    ``jnp.interp``.
+
+    Args:
+        k_arr (array-like): Wavenumbers [h/Mpc], sorted ascending.
+        pk_arr (array-like): Power spectrum values [(Mpc/h)³].
+
+    Returns:
+        Callable: ``pk(k)`` accepting JAX arrays, returning P(k) [(Mpc/h)³].
+    """
+    log_k = jnp.log(jnp.asarray(k_arr, dtype=jnp.float32))
+    log_pk = jnp.log(jnp.asarray(pk_arr, dtype=jnp.float32))
+
+    def pk_callable(k):
+        return jnp.exp(jnp.interp(jnp.log(k), log_k, log_pk))
+
+    return pk_callable
+
+
+def make_pk_callable_from_dict(power_spectrum_dict, kind="vv"):
+    """Build a P(k) callable from a flip-style power_spectrum_dict.
+
+    Flip's ``power_spectrum_dict`` has keys ``"gg"``, ``"vv"``, ``"gv"``,
+    each mapping to a 2-column array ``[[k, P(k)], …]`` or a list of such
+    arrays (one per redshift bin). This function wraps the first entry.
+
+    Args:
+        power_spectrum_dict (dict): Flip power spectrum dict.
+        kind (str): Which spectrum to extract: ``"gg"``, ``"vv"``, or ``"gv"``.
+            Defaults to ``"vv"`` (velocity–velocity, needed for PM simulations).
+
+    Returns:
+        Callable: JAX-differentiable ``pk(k)``.
+
+    Raises:
+        KeyError: If ``kind`` is not present in ``power_spectrum_dict``.
+    """
+    if kind not in power_spectrum_dict:
+        raise KeyError(
+            f"Key '{kind}' not found in power_spectrum_dict. "
+            f"Available: {list(power_spectrum_dict.keys())}"
+        )
+    entry = power_spectrum_dict[kind]
+    # Entry is either [[k, Pk], …] (2D array) or a list of such arrays
+    arr = jnp.asarray(entry[0] if isinstance(entry, list) else entry)
+    k_arr, pk_arr = arr[:, 0], arr[:, 1]
+    return make_pk_callable(k_arr, pk_arr)

--- a/flip/simulation/fitter.py
+++ b/flip/simulation/fitter.py
@@ -1,0 +1,134 @@
+"""Gradient-based optimizer for the simulation likelihood.
+
+:class:`SimulationFitter` minimizes the negative log-likelihood of a
+:class:`~flip.simulation.likelihood.VelocityFieldLikelihood` (or any callable
+returning a scalar loss) using gradient-based solvers from ``jaxopt``.
+
+All solvers use ``jax.grad`` through the forward model, so full end-to-end
+automatic differentiation is available.
+
+Example::
+
+    from flip.simulation.fitter import SimulationFitter
+
+    fitter = SimulationFitter(
+        likelihood=lik,
+        initial_params={"omega_m": 0.3, "sigma8": 0.8},
+        bounds=({"omega_m": 0.1, "sigma8": 0.3},
+                {"omega_m": 0.9, "sigma8": 1.5}),
+        solver="LBFGSB",
+        maxiter=200,
+    )
+    best_params = fitter.run()
+"""
+
+import jax.numpy as jnp
+import jaxopt
+
+from flip.utils import create_log
+
+log = create_log()
+
+_AVAILABLE_SOLVERS = {
+    "LBFGS": jaxopt.LBFGS,
+    "LBFGSB": jaxopt.LBFGSB,
+    "BFGS": jaxopt.BFGS,
+    "GradientDescent": jaxopt.GradientDescent,
+}
+
+
+class SimulationFitter:
+    """Minimize the simulation likelihood over cosmological parameters.
+
+    Parameters are represented as a flat JAX array internally and converted
+    to/from a dict for the likelihood interface.
+
+    Args:
+        likelihood (callable): Callable ``(params_dict) → scalar loss``.
+            Typically a :class:`~flip.simulation.likelihood.VelocityFieldLikelihood`.
+        initial_params (dict): Initial cosmological parameter values,
+            e.g. ``{"omega_m": 0.3, "sigma8": 0.8}``.
+        bounds (tuple[dict, dict] | None): Optional box constraints
+            ``(lower_dict, upper_dict)`` with the same keys as
+            ``initial_params``. Only used when ``solver="LBFGSB"``.
+        solver (str): jaxopt solver name: ``"LBFGS"`` (default), ``"LBFGSB"``,
+            ``"BFGS"``, or ``"GradientDescent"``.
+        maxiter (int): Maximum optimizer iterations. Default 100.
+        solver_kwargs (dict | None): Extra kwargs forwarded to the jaxopt
+            solver constructor (e.g. ``tol``, ``stepsize``).
+
+    Raises:
+        ValueError: If ``solver`` is not one of the supported names.
+    """
+
+    def __init__(
+        self,
+        likelihood,
+        initial_params,
+        bounds=None,
+        solver="LBFGS",
+        maxiter=100,
+        solver_kwargs=None,
+    ):
+        if solver not in _AVAILABLE_SOLVERS:
+            raise ValueError(
+                f"Solver '{solver}' not supported. "
+                f"Choose from: {list(_AVAILABLE_SOLVERS.keys())}"
+            )
+        self.likelihood = likelihood
+        self.initial_params = initial_params
+        self.bounds = bounds
+        self.solver_name = solver
+        self.maxiter = maxiter
+        self.solver_kwargs = solver_kwargs or {}
+        self._result = None
+        self._param_names = list(initial_params.keys())
+
+    def _to_array(self, params_dict):
+        return jnp.array([params_dict[k] for k in self._param_names])
+
+    def _to_dict(self, params_array):
+        return {k: float(params_array[i]) for i, k in enumerate(self._param_names)}
+
+    def _objective(self, params_array):
+        return self.likelihood(self._to_dict(params_array))
+
+    def run(self):
+        """Run the optimization and return the best-fit parameter dict.
+
+        The raw jaxopt result is stored in :attr:`result` after completion.
+
+        Returns:
+            dict: Best-fit parameters with the same keys as ``initial_params``.
+        """
+        initial_array = self._to_array(self.initial_params)
+
+        solver_cls = _AVAILABLE_SOLVERS[self.solver_name]
+        kwargs = {"fun": self._objective, "maxiter": self.maxiter, **self.solver_kwargs}
+        solver = solver_cls(**kwargs)
+
+        if self.bounds is not None and self.solver_name == "LBFGSB":
+            lower = jnp.array([self.bounds[0].get(k, -jnp.inf) for k in self._param_names])
+            upper = jnp.array([self.bounds[1].get(k, jnp.inf) for k in self._param_names])
+            result = solver.run(initial_array, bounds=(lower, upper))
+        else:
+            result = solver.run(initial_array)
+
+        self._result = result
+
+        try:
+            log.info(
+                "SimulationFitter (%s): %d iterations, final loss=%.6g",
+                self.solver_name,
+                result.state.iter_num,
+                result.state.value,
+            )
+        except AttributeError:
+            log.info("SimulationFitter (%s): optimization complete.", self.solver_name)
+
+        return self._to_dict(result.params)
+
+    @property
+    def result(self):
+        """Raw jaxopt result from the last :meth:`run` call, or ``None``."""
+        return self._result

--- a/flip/simulation/generator.py
+++ b/flip/simulation/generator.py
@@ -1,0 +1,394 @@
+"""Differentiable forward model: initial conditions + LPT/PM evolution via JaxPM.
+
+This module implements a JAX-differentiable pipeline:
+
+    cosmology + P(k) + seed → Gaussian IC → LPT displacements → [PM] → fields
+
+Key design choices (informed by copilot branch review):
+
+* **DC-mode-safe IC generation**: :func:`_differentiable_linear_field` replaces
+  ``jaxpm.pm.linear_field`` with a version that avoids NaN gradients at k=0
+  by masking the DC mode multiplicatively (so its gradient is 0, not NaN).
+* **Manual 1LPT**: :func:`_run_lpt` reimplements 1LPT without calling
+  ``jaxpm.pm.lpt`` to avoid a known caching incompatibility in jaxpm when
+  a JAX-traced cosmology is passed (breaks ``jax.grad``).
+* **PM time-stepping** (optional): :class:`ForwardModel` also supports full
+  leapfrog PM integration for beyond-ZA accuracy.
+
+Typical usage::
+
+    from flip.simulation.generator import ForwardModel, get_cosmology
+
+    cosmo = get_cosmology(omega_m=0.3, sigma8=0.8)
+    model = ForwardModel(mesh_shape=(64,64,64), box_size=(512.,512.,512.),
+                         a_final=1.0, lpt_only=True)
+    density, velocity = model.get_fields(cosmo, seed=42)
+"""
+
+import math
+
+try:
+    import jax
+    import jax.numpy as jnp
+    import jax_cosmo as jc
+    from jax_cosmo import background, power
+    from jaxpm.distributed import fft3d, ifft3d, normal_field
+    from jaxpm.growth import growth_factor, growth_rate
+    from jaxpm.kernels import fftk
+    from jaxpm.painting import cic_paint_dx
+    from jaxpm.pm import pm_forces
+except ImportError:
+    import numpy as jnp
+
+from flip.utils import create_log
+
+log = create_log()
+
+#: H₀ in km/s/(Mpc/h). The h factors cancel: H₀ = 100h km/s/Mpc, 1 Mpc/h = (1/h) Mpc.
+_H0_UNIT = 100.0
+
+
+def get_cosmology(
+    omega_m,
+    sigma8,
+    h=0.6774,
+    omega_b=0.0486,
+    n_s=0.9667,
+    w0=-1.0,
+    wa=0.0,
+    omega_k=0.0,
+):
+    """Build a ``jax_cosmo.Cosmology`` from standard parameters.
+
+    Args:
+        omega_m (float): Total matter density Ω_m.
+        sigma8 (float): RMS matter fluctuation amplitude σ₈.
+        h (float): Dimensionless Hubble parameter. Default 0.6774.
+        omega_b (float): Baryon density Ω_b. Default 0.0486.
+        n_s (float): Scalar spectral index. Default 0.9667.
+        w0 (float): Dark energy EoS constant. Default -1.0.
+        wa (float): Dark energy EoS evolution. Default 0.0.
+        omega_k (float): Curvature density. Default 0.0.
+
+    Returns:
+        jax_cosmo.Cosmology: Ready for JaxPM simulations.
+    """
+    return jc.Cosmology(
+        h=h,
+        Omega_b=omega_b,
+        Omega_c=omega_m - omega_b,
+        w0=w0,
+        wa=wa,
+        n_s=n_s,
+        sigma8=sigma8,
+        Omega_k=omega_k,
+    )
+
+
+def _differentiable_linear_field(mesh_shape, box_size, pk_fn, seed):
+    """Generate a Gaussian linear density field with NaN-safe gradients at k=0.
+
+    ``jaxpm.pm.linear_field`` evaluates P(k) at all modes including k=0
+    (the DC mode).  For typical jax_cosmo power spectra, P(0) = 0 but
+    ∂P/∂σ₈ at k=0 is NaN, which corrupts ``jax.grad``.  This function
+    avoids the issue by:
+
+    1. Replacing k=0 with a dummy value (k=1) before calling ``pk_fn``.
+    2. Setting the DC amplitude to zero with a **multiplicative** mask
+       (not ``jnp.where``), so the gradient of the mask itself is 0, not NaN.
+
+    Args:
+        mesh_shape (tuple[int, int, int]): Grid dimensions.
+        box_size (jnp.ndarray): Box size [Lx, Ly, Lz] in Mpc/h.
+        pk_fn (callable): P(k) mapping wavenumbers [h/Mpc] → [(Mpc/h)³].
+        seed (jax.random.PRNGKey): Random seed.
+
+    Returns:
+        jnp.ndarray: Real-space linear density field, shape ``mesh_shape``.
+    """
+    field = normal_field(seed=seed, shape=mesh_shape)
+    field = fft3d(field)
+
+    kvec = fftk(field)
+    kmesh = sum(
+        (kk / box_size[i] * mesh_shape[i]) ** 2 for i, kk in enumerate(kvec)
+    ) ** 0.5
+
+    # Replace k=0 with 1.0 to avoid NaN from pk_fn at DC mode
+    kmesh_safe = jnp.where(kmesh > 0, kmesh, jnp.ones_like(kmesh))
+
+    volume = jnp.prod(jnp.array(mesh_shape)) / jnp.prod(box_size)
+    pkmesh = pk_fn(kmesh_safe) * volume
+
+    # Multiplicative mask: gradient is 0 at DC mode (not NaN as with jnp.where)
+    dc_mask = (kmesh > 0).astype(jnp.float32)
+
+    field = field * jnp.sqrt(pkmesh) * dc_mask
+    return ifft3d(field)
+
+
+def _run_lpt(cosmo, initial_conditions, a):
+    """Manual 1LPT (Zel'dovich approximation): avoids jaxpm caching bug.
+
+    ``jaxpm.pm.lpt`` calls ``dGfa`` internally, which has a known caching
+    incompatibility when the cosmology is a JAX-traced value (as during
+    ``jax.grad``).  This function reimplements 1LPT directly:
+
+        dx = D₁(a) × Ψ    (Zel'dovich displacement)
+        p  = a² f₁ H(a) dx  (canonical momentum)
+
+    where Ψ is the Zel'dovich displacement field from the gravitational force.
+
+    Args:
+        cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+        initial_conditions (jnp.ndarray): Linear density field on the mesh,
+            shape ``mesh_shape``.
+        a (float): Scale factor.
+
+    Returns:
+        tuple[jnp.ndarray, jnp.ndarray]: ``(dx, p)`` — displacement and
+        canonical momentum, both shape ``(*mesh_shape, 3)``.
+    """
+    mesh_shape = initial_conditions.shape
+    a_arr = jnp.atleast_1d(a)
+
+    E = jnp.sqrt(background.Esqr(cosmo, a_arr))[0]
+    D1 = growth_factor(cosmo, a_arr)[0]
+    f1 = growth_rate(cosmo, a_arr)[0]
+
+    # Gravitational force from the linear density field (Ψ in ZA)
+    particles = jnp.zeros((*mesh_shape, 3))
+    delta_k = fft3d(initial_conditions)
+    psi = pm_forces(particles, delta=delta_k, paint_absolute_pos=False)
+
+    dx = D1 * psi
+    p = a_arr[0] ** 2 * f1 * E * dx
+    return dx, p
+
+
+class ForwardModel:
+    """JAX-differentiable forward model: cosmology → density & velocity fields.
+
+    Wraps JaxPM's LPT (and optionally PM time-stepping) to produce density
+    contrast and peculiar velocity fields on a 3D Cartesian mesh. The full
+    pipeline is differentiable w.r.t. cosmological parameters.
+
+    Uses a DC-mode-safe IC generator and a manual 1LPT implementation
+    to ensure ``jax.grad`` works correctly through the full pipeline.
+
+    Args:
+        mesh_shape (tuple[int, int, int]): Grid resolution (Nx, Ny, Nz).
+            Fixed at construction; JAX traces static shapes.
+        box_size (tuple[float, float, float]): Box dimensions in Mpc/h.
+        a_final (float): Target scale factor (``1/(1+z_survey)``). Default: 1.0.
+        a_initial (float): Scale factor for LPT initial conditions when
+            ``lpt_only=False``. Default: 0.1.
+        n_steps (int): PM leapfrog time steps. Ignored when ``lpt_only=True``.
+        lpt_only (bool): If True, skip PM and use 1LPT positions directly.
+            Faster and differentiable; less accurate at small scales.
+        pk_fn (callable | None): P(k) callable ``k [h/Mpc] → P(k) [(Mpc/h)³]``.
+            If None, uses ``jax_cosmo.power.linear_matter_power`` evaluated at
+            ``a_final``. Pass a custom callable to use CLASS/CAMB spectra.
+    """
+
+    def __init__(
+        self,
+        mesh_shape,
+        box_size,
+        a_final=1.0,
+        a_initial=0.1,
+        n_steps=10,
+        lpt_only=True,
+        pk_fn=None,
+    ):
+        self.mesh_shape = tuple(int(n) for n in mesh_shape)
+        self.box_size = jnp.array(box_size, dtype=jnp.float32)
+        self.a_final = float(a_final)
+        self.a_initial = float(a_initial)
+        self.n_steps = int(n_steps)
+        self.lpt_only = bool(lpt_only)
+        self._pk_fn_override = pk_fn
+
+        log.info(
+            "ForwardModel: mesh=%s, box=%s Mpc/h, a_final=%.4f, lpt_only=%s",
+            self.mesh_shape,
+            tuple(float(x) for x in self.box_size),
+            self.a_final,
+            self.lpt_only,
+        )
+
+    # ------------------------------------------------------------------
+    # Core pipeline steps
+    # ------------------------------------------------------------------
+
+    def _get_pk_fn(self, cosmo):
+        """Return the P(k) callable for initial condition generation."""
+        if self._pk_fn_override is not None:
+            return self._pk_fn_override
+        a = self.a_final
+
+        def pk(k):
+            return power.linear_matter_power(cosmo, k, a=a)
+
+        return pk
+
+    def generate_initial_conditions(self, cosmo, seed):
+        """Draw a Gaussian random linear density field.
+
+        Args:
+            cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+            seed (int | jax.random.PRNGKey): Random seed.
+
+        Returns:
+            jnp.ndarray: Linear density field of shape ``mesh_shape``.
+        """
+        if isinstance(seed, int):
+            seed = jax.random.PRNGKey(seed)
+        pk_fn = self._get_pk_fn(cosmo)
+        return _differentiable_linear_field(self.mesh_shape, self.box_size, pk_fn, seed)
+
+    def run_lpt(self, cosmo, initial_conditions, a=None):
+        """Apply 1LPT to produce displacements and momenta.
+
+        Args:
+            cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+            initial_conditions (jnp.ndarray): Linear density field.
+            a (float | None): Scale factor. Defaults to ``a_final``.
+
+        Returns:
+            tuple[jnp.ndarray, jnp.ndarray]: ``(dx, p)`` — displacement and
+            canonical momentum, both shape ``(*mesh_shape, 3)``.
+        """
+        if a is None:
+            a = self.a_final
+        return _run_lpt(cosmo, initial_conditions, a)
+
+    def run_pm(self, cosmo, dx_init, p_init, a_out=None):
+        """Integrate PM equations of motion from ``a_initial`` to ``a_final``.
+
+        Args:
+            cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+            dx_init (jnp.ndarray): LPT displacements at ``a_initial``.
+            p_init (jnp.ndarray): LPT momenta at ``a_initial``.
+            a_out (jnp.ndarray | None): Output scale factors. Last entry is
+                the output epoch. Defaults to linspace.
+
+        Returns:
+            tuple[jnp.ndarray, jnp.ndarray]: ``(dx, p)`` at last ``a_out``.
+        """
+        from jax.experimental.ode import odeint
+        from jaxpm.pm import make_ode_fn
+
+        if a_out is None:
+            a_out = jnp.linspace(self.a_initial, self.a_final, self.n_steps)
+
+        ode_fn = make_ode_fn(self.mesh_shape)
+        traj = odeint(
+            ode_fn,
+            [dx_init, p_init],
+            a_out,
+            cosmo,
+            self.mesh_shape,
+            self.box_size,
+        )
+        return traj[-1, 0], traj[-1, 1]
+
+    # ------------------------------------------------------------------
+    # High-level entry points
+    # ------------------------------------------------------------------
+
+    def __call__(self, cosmo, seed, a_out=None):
+        """Run forward model: cosmology + seed → (displacement, momentum).
+
+        Args:
+            cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+            seed (int | jax.random.PRNGKey): IC random seed.
+            a_out (jnp.ndarray | None): PM output scale factors (PM mode only).
+
+        Returns:
+            tuple[jnp.ndarray, jnp.ndarray]: ``(dx, p)`` at ``a_final``.
+        """
+        ic = self.generate_initial_conditions(cosmo, seed)
+        dx, p = self.run_lpt(cosmo, ic)
+        if self.lpt_only:
+            return dx, p
+        return self.run_pm(cosmo, dx, p, a_out=a_out)
+
+    def get_fields(self, cosmo, seed, a_out=None):
+        """Run simulation and return density contrast + velocity fields.
+
+        Args:
+            cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+            seed (int | jax.random.PRNGKey): IC random seed.
+            a_out (jnp.ndarray | None): PM output scale factors (PM mode).
+
+        Returns:
+            tuple[jnp.ndarray, jnp.ndarray]:
+              * ``density_field``: δ(x), shape ``mesh_shape``.
+              * ``velocity_field``: v(x) in km/s, shape ``(*mesh_shape, 3)``.
+        """
+        dx, p = self(cosmo, seed, a_out=a_out)
+
+        density_field = cic_paint_dx(dx)
+
+        a_arr = jnp.atleast_1d(self.a_final)
+        E = jnp.sqrt(background.Esqr(cosmo, a_arr))[0]
+        cell_size = self.box_size / jnp.array(self.mesh_shape, dtype=jnp.float32)
+        velocity_field = p / (a_arr[0] ** 2 * E) * cell_size * _H0_UNIT
+
+        return density_field, velocity_field
+
+    # ------------------------------------------------------------------
+    # Convenience constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_survey_geometry(
+        cls,
+        rcom_max,
+        cell_size_mpc,
+        z_survey=0.0,
+        lpt_only=True,
+        n_steps=10,
+        padding_factor=1.2,
+    ):
+        """Build a ForwardModel sized to enclose a given survey volume.
+
+        Box side is ``2 × rcom_max × padding_factor``, snapped to a power of
+        two for FFT efficiency.
+
+        Args:
+            rcom_max (float): Maximum survey comoving distance [Mpc/h].
+            cell_size_mpc (float): Target cell size [Mpc/h].
+            z_survey (float): Survey redshift (sets ``a_final``).
+            lpt_only (bool): Use LPT only (default True).
+            n_steps (int): PM steps when ``lpt_only=False``.
+            padding_factor (float): Box padding. Default 1.2.
+
+        Returns:
+            ForwardModel: Configured instance.
+        """
+        box_side_raw = 2.0 * rcom_max * padding_factor
+        n_mesh = int(2 ** round(math.log2(box_side_raw / cell_size_mpc)))
+        box_side = n_mesh * cell_size_mpc
+        a_final = 1.0 / (1.0 + float(z_survey))
+
+        log.info(
+            "ForwardModel.from_survey_geometry: rcom_max=%.1f, cell=%.1f → "
+            "mesh=(%d,%d,%d), box=%.1f Mpc/h, a_final=%.4f",
+            rcom_max, cell_size_mpc, n_mesh, n_mesh, n_mesh, box_side, a_final,
+        )
+        return cls(
+            mesh_shape=(n_mesh, n_mesh, n_mesh),
+            box_size=(box_side, box_side, box_side),
+            a_final=a_final,
+            lpt_only=lpt_only,
+            n_steps=n_steps,
+        )
+
+    def __repr__(self):
+        return (
+            f"ForwardModel(mesh={self.mesh_shape}, "
+            f"box={tuple(float(x) for x in self.box_size)}, "
+            f"a_final={self.a_final:.4f}, lpt_only={self.lpt_only})"
+        )

--- a/flip/simulation/likelihood.py
+++ b/flip/simulation/likelihood.py
@@ -1,0 +1,167 @@
+"""Gaussian field-level likelihood for forward-model velocity inference.
+
+Provides:
+
+* :func:`log_likelihood_gaussian` — scalar log-likelihood under diagonal
+  or full Gaussian noise, differentiable via JAX.
+* :class:`VelocityFieldLikelihood` — full likelihood callable that wraps a
+  :class:`~flip.simulation.generator.ForwardModel` and compares its output to
+  a flip :class:`~flip.data_vector.basic.DataVector`.
+
+The likelihood is end-to-end differentiable w.r.t. cosmological parameters,
+enabling gradient-based maximization (:class:`~flip.simulation.fitter.SimulationFitter`)
+or HMC sampling.
+
+Example::
+
+    import jax
+    from flip.simulation.generator import ForwardModel, get_cosmology
+    from flip.simulation.likelihood import VelocityFieldLikelihood
+
+    model = ForwardModel(mesh_shape=(32,32,32), box_size=(256.,256.,256.))
+    lik = VelocityFieldLikelihood(
+        forward_model=model,
+        data_vector=my_vel_dv,
+        positions_cartesian=galaxy_xyz,
+        seed=jax.random.PRNGKey(0),
+    )
+    neg_log_lik = lik({"omega_m": 0.3, "sigma8": 0.8})
+"""
+
+import jax.numpy as jnp
+import jax.scipy as jsc
+
+from flip.simulation import generator as gen
+from flip.simulation import painter
+from flip.utils import create_log
+
+log = create_log()
+
+
+def log_likelihood_gaussian(simulated_velocity, observed_velocity, observed_variance):
+    """Gaussian log-likelihood between simulated and observed LOS velocities.
+
+    Supports both **diagonal** (independent Gaussian errors) and **full**
+    covariance matrices.
+
+    Diagonal form:
+
+    .. math::
+
+        \\log\\mathcal{L} = -\\tfrac{1}{2}\\sum_i
+        \\left[\\frac{(v^\\text{obs}_i - v^\\text{sim}_i)^2}{\\sigma_i^2}
+        + \\log(2\\pi\\sigma_i^2)\\right]
+
+    Args:
+        simulated_velocity (jnp.ndarray): Simulated LOS velocities [km/s],
+            shape ``(N,)``.
+        observed_velocity (jnp.ndarray): Observed velocities [km/s],
+            shape ``(N,)``.
+        observed_variance (jnp.ndarray): Measurement (co)variance.  1-D array
+            of shape ``(N,)`` for independent errors; 2-D array of shape
+            ``(N, N)`` for full covariance.
+
+    Returns:
+        float: Log-likelihood value.
+    """
+    residual = observed_velocity - simulated_velocity
+    if observed_variance.ndim == 2:
+        chol = jsc.linalg.cho_factor(observed_variance)
+        logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(chol[0])))
+        chi2 = jnp.dot(residual, jsc.linalg.cho_solve(chol, residual))
+        n = residual.size
+        return -0.5 * (chi2 + logdet + n * jnp.log(2.0 * jnp.pi))
+    else:
+        logdet = jnp.sum(jnp.log(2.0 * jnp.pi * observed_variance))
+        chi2 = jnp.sum(residual**2 / observed_variance)
+        return -0.5 * (chi2 + logdet)
+
+
+class VelocityFieldLikelihood:
+    """Gaussian likelihood comparing a forward simulation to observed velocities.
+
+    For a given cosmology, this callable:
+
+    1. Runs the :class:`~flip.simulation.generator.ForwardModel` to get δ and v fields.
+    2. Interpolates the velocity field at observed galaxy positions (Cartesian,
+       box frame).
+    3. Projects onto the line of sight.
+    4. Evaluates the Gaussian log-likelihood and returns its negation
+       (for minimization).
+
+    The entire chain is JAX-differentiable w.r.t. cosmological parameters,
+    so gradients for optimization or HMC are available via ``jax.grad``.
+
+    Args:
+        forward_model (ForwardModel): Configured simulation instance.
+        data_vector (flip DataVector): Velocity data vector with a
+            ``give_data_and_variance(**kwargs)`` method.
+        positions_cartesian (array-like): Galaxy Cartesian positions [Mpc/h]
+            in the **box frame** (origin at box corner), shape ``(N, 3)``.
+            Use :func:`~flip.simulation.painter.sky_to_cartesian` +
+            :func:`~flip.simulation.painter.cartesian_to_box_frame` to convert.
+        seed (int | jax.random.PRNGKey): IC random seed. Fixed across calls.
+        parameter_values_dict (dict | None): Extra parameters for the data
+            vector's ``give_data_and_variance`` method (e.g. ``{"M_0": -19.3}``
+            for ``VelFromHDres``). Default: empty dict.
+    """
+
+    def __init__(
+        self,
+        forward_model,
+        data_vector,
+        positions_cartesian,
+        seed,
+        parameter_values_dict=None,
+    ):
+        self.forward_model = forward_model
+        self.data_vector = data_vector
+        self.positions_cartesian = jnp.array(positions_cartesian, dtype=jnp.float32)
+        self.seed = seed
+        self.parameter_values_dict = parameter_values_dict or {}
+
+        # Pre-compute observed velocities and variances (fixed across calls)
+        obs_vel, obs_var = self.data_vector.give_data_and_variance(
+            self.parameter_values_dict
+        )
+        self.observed_velocity = jnp.array(obs_vel)
+        self.observed_variance = jnp.array(obs_var)
+
+        log.info(
+            "VelocityFieldLikelihood: %d observations, mesh %s, box %s Mpc/h",
+            len(self.observed_velocity),
+            self.forward_model.mesh_shape,
+            tuple(float(x) for x in self.forward_model.box_size),
+        )
+
+    def __call__(self, cosmo_params):
+        """Evaluate the negative log-likelihood.
+
+        Args:
+            cosmo_params (dict): Cosmological parameters accepted by
+                :func:`~flip.simulation.generator.get_cosmology`.  At minimum
+                ``omega_m`` and ``sigma8`` must be provided.
+
+        Returns:
+            float: Negative log-likelihood (suitable for minimization).
+        """
+        cosmo = gen.get_cosmology(**cosmo_params)
+
+        _, velocity_field = self.forward_model.get_fields(cosmo, self.seed)
+
+        velocities_3d = painter.interpolate_velocity_to_positions(
+            velocity_field,
+            self.positions_cartesian,
+            self.forward_model.box_size,
+            self.forward_model.mesh_shape,
+        )
+
+        simulated_los = painter.compute_los_velocity(
+            velocities_3d, self.positions_cartesian
+        )
+
+        return -log_likelihood_gaussian(
+            simulated_los,
+            self.observed_velocity,
+            self.observed_variance,
+        )

--- a/flip/simulation/painter.py
+++ b/flip/simulation/painter.py
@@ -1,0 +1,201 @@
+"""Extract observables from density and velocity fields.
+
+Given the ``(density_field, velocity_field)`` output of
+:meth:`~flip.simulation.generator.ForwardModel.get_fields`, this module provides:
+
+* **CIC interpolation** at arbitrary positions — a custom implementation
+  compatible with arbitrary batch sizes and JAX tracing.
+* **Line-of-sight projection** ``v_los = v · r̂``, with safe zero-norm handling.
+* **Sky ↔ Cartesian** coordinate conversions (RA/Dec in radians, flip convention).
+* **RSD positions**: shift galaxies along LOS by ``v_los / (aH)`` for
+  redshift-space mock catalogs.
+
+Coordinate conventions (consistent with flip throughout):
+  * RA / Dec in **radians**
+  * Comoving distance in Mpc/h
+  * Velocities in km/s
+  * Positions passed to interpolation routines in Mpc/h (Cartesian, box frame)
+"""
+
+try:
+    import jax.numpy as jnp
+except ImportError:
+    import numpy as jnp
+
+
+def _cic_read(grid_mesh, positions):
+    """CIC-interpolate a 3D scalar field at arbitrary positions.
+
+    Custom JAX-differentiable trilinear interpolation compatible with
+    arbitrary batch sizes (unlike some jaxpm versions whose ``cic_read``
+    requires positions to match the grid shape).  Periodic BCs applied.
+
+    Args:
+        grid_mesh (jnp.ndarray): Scalar field of shape ``(Nx, Ny, Nz)``.
+        positions (jnp.ndarray): Positions in mesh-cell units ``[0, Ni)``,
+            shape ``(N, 3)``.
+
+    Returns:
+        jnp.ndarray: Interpolated values at each position, shape ``(N,)``.
+    """
+    pos = jnp.expand_dims(positions, -2)  # (N, 1, 3)
+
+    offsets = jnp.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+         [1, 1, 0], [1, 0, 1], [0, 1, 1], [1, 1, 1]],
+        dtype=jnp.float32,
+    )[jnp.newaxis]  # (1, 8, 3)
+
+    floor_pos = jnp.floor(pos)                # (N, 1, 3)
+    neighbours = floor_pos + offsets          # (N, 8, 3)
+    kernel = 1.0 - jnp.abs(pos - neighbours)  # (N, 8, 3)
+    kernel = kernel[..., 0] * kernel[..., 1] * kernel[..., 2]  # (N, 8)
+
+    grid_shape = jnp.array(grid_mesh.shape)
+    idx = jnp.mod(neighbours.astype(jnp.int32), grid_shape)  # (N, 8, 3)
+    values = grid_mesh[idx[..., 0], idx[..., 1], idx[..., 2]]  # (N, 8)
+    return (values * kernel).sum(axis=-1)  # (N,)
+
+
+def _safe_normalize(positions):
+    """Return unit vectors along each position vector; zero vector → zero.
+
+    Args:
+        positions (jnp.ndarray): Cartesian positions [Mpc/h], shape ``(N, 3)``.
+
+    Returns:
+        jnp.ndarray: Unit vectors, shape ``(N, 3)``.
+    """
+    r = jnp.linalg.norm(positions, axis=-1, keepdims=True)
+    return positions / jnp.where(r > 0, r, jnp.ones_like(r))
+
+
+def compute_los_velocity(velocities, positions):
+    """Project 3D velocities onto the line-of-sight direction.
+
+    Observer at the Cartesian origin; LOS direction is r̂ = pos / |pos|.
+
+    Args:
+        velocities (jnp.ndarray): Peculiar velocities [km/s], shape ``(N, 3)``.
+        positions (jnp.ndarray): Galaxy positions [Mpc/h], shape ``(N, 3)``.
+
+    Returns:
+        jnp.ndarray: Line-of-sight velocities [km/s], shape ``(N,)``.
+    """
+    los_unit = _safe_normalize(positions)
+    return jnp.sum(velocities * los_unit, axis=-1)
+
+
+def interpolate_velocity_to_positions(velocity_field, positions, box_size, mesh_shape):
+    """CIC-interpolate a 3D velocity field at galaxy positions.
+
+    Args:
+        velocity_field (jnp.ndarray): Velocity field [km/s], shape
+            ``(*mesh_shape, 3)``.
+        positions (jnp.ndarray): Galaxy positions [Mpc/h], shape ``(N, 3)``.
+            Coordinates must lie within ``[0, box_size)`` along each axis.
+        box_size (array-like): Box dimensions [Mpc/h], shape ``(3,)``.
+        mesh_shape (array-like): Grid resolution, shape ``(3,)``.
+
+    Returns:
+        jnp.ndarray: Velocity at each galaxy [km/s], shape ``(N, 3)``.
+    """
+    box_size = jnp.array(box_size, dtype=jnp.float32)
+    mesh_arr = jnp.array(mesh_shape, dtype=jnp.float32)
+    pos_mesh = positions / box_size * mesh_arr  # Mpc/h → mesh units
+    return jnp.stack(
+        [_cic_read(velocity_field[..., i], pos_mesh) for i in range(3)],
+        axis=-1,
+    )
+
+
+def interpolate_density_to_positions(density_field, positions, box_size, mesh_shape):
+    """CIC-interpolate the density contrast δ(x) at galaxy positions.
+
+    Args:
+        density_field (jnp.ndarray): Density contrast δ, shape ``mesh_shape``.
+        positions (jnp.ndarray): Galaxy positions [Mpc/h], shape ``(N, 3)``.
+        box_size (array-like): Box dimensions [Mpc/h].
+        mesh_shape (array-like): Grid resolution.
+
+    Returns:
+        jnp.ndarray: δ at each galaxy, shape ``(N,)``.
+    """
+    box_size = jnp.array(box_size, dtype=jnp.float32)
+    mesh_arr = jnp.array(mesh_shape, dtype=jnp.float32)
+    pos_mesh = positions / box_size * mesh_arr
+    return _cic_read(density_field, pos_mesh)
+
+
+def sky_to_cartesian(ra, dec, rcom):
+    """Convert sky coordinates to Cartesian positions in Mpc/h.
+
+    RA/Dec in **radians** (flip convention).
+
+    Args:
+        ra (jnp.ndarray): Right ascension in radians, shape ``(N,)``.
+        dec (jnp.ndarray): Declination in radians, shape ``(N,)``.
+        rcom (jnp.ndarray): Comoving distance in Mpc/h, shape ``(N,)``.
+
+    Returns:
+        jnp.ndarray: Cartesian positions [Mpc/h], shape ``(N, 3)``.
+    """
+    cos_dec = jnp.cos(dec)
+    x = rcom * cos_dec * jnp.cos(ra)
+    y = rcom * cos_dec * jnp.sin(ra)
+    z = rcom * jnp.sin(dec)
+    return jnp.stack([x, y, z], axis=-1)
+
+
+def cartesian_to_box_frame(positions, box_size, center_offset=None):
+    """Shift Cartesian positions from observer-centred to box-corner frame.
+
+    The simulation box has its corner at the origin; the observer sits at the
+    box centre (or at ``center_offset`` if provided).
+
+    Args:
+        positions (jnp.ndarray): Observer-centred Cartesian positions [Mpc/h],
+            shape ``(N, 3)``.
+        box_size (array-like): Box dimensions [Mpc/h].
+        center_offset (jnp.ndarray | None): Position of the observer relative
+            to the box corner [Mpc/h]. Defaults to the box centre (L/2, L/2, L/2).
+
+    Returns:
+        jnp.ndarray: Box-frame positions [Mpc/h], shape ``(N, 3)``.
+    """
+    box = jnp.array(box_size, dtype=jnp.float32)
+    if center_offset is None:
+        center_offset = box / 2.0
+    return positions + center_offset
+
+
+def apply_rsd(positions_box, velocities, cosmo, a, box_size, los_axis=2):
+    """Shift positions along the LOS by the plane-parallel RSD displacement.
+
+    Applies  x_rsd = x + v_los / (a H(a))  in Mpc/h, then wraps periodically.
+
+    Args:
+        positions_box (jnp.ndarray): Galaxy positions in box frame [Mpc/h],
+            shape ``(N, 3)``.
+        velocities (jnp.ndarray): Peculiar velocities [km/s], shape ``(N, 3)``
+            or ``(N,)`` if already projected on ``los_axis``.
+        cosmo (jax_cosmo.Cosmology): Cosmological parameters.
+        a (float): Scale factor.
+        box_size (array-like): Box dimensions [Mpc/h].
+        los_axis (int): Axis along which to apply RSD (0, 1, or 2). Default 2.
+
+    Returns:
+        jnp.ndarray: Redshift-space positions [Mpc/h], shape ``(N, 3)``.
+    """
+    from jax_cosmo import background
+
+    a_arr = jnp.atleast_1d(a)
+    E = jnp.sqrt(background.Esqr(cosmo, a_arr))[0]
+    H_a = 100.0 * cosmo.h * E  # km/s / (Mpc/h)
+
+    v_los = velocities if velocities.ndim == 1 else velocities[:, los_axis]
+    rsd_shift = v_los / (a * H_a)  # Mpc/h
+
+    box = jnp.array(box_size, dtype=jnp.float32)
+    new_pos = positions_box.at[:, los_axis].add(rsd_shift)
+    return new_pos % box

--- a/notebooks/simulation_forward_model.ipynb
+++ b/notebooks/simulation_forward_model.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# flip.simulation — Forward Model Demo\n",
+    "\n",
+    "This notebook walks through the `flip.simulation` submodule end-to-end:\n",
+    "\n",
+    "1. Setting up a cosmology and a `ForwardModel`\n",
+    "2. Generating density and velocity fields\n",
+    "3. Extracting line-of-sight velocities at galaxy positions\n",
+    "4. Evaluating a field-level Gaussian likelihood\n",
+    "5. Computing gradients through the full pipeline\n",
+    "6. (Optional) Running a gradient-based fit with `SimulationFitter`\n",
+    "\n",
+    "**Required packages:** `jaxpm`, `jax_cosmo`, and optionally `jaxopt` for the fitter.\n",
+    "\n",
+    "```bash\n",
+    "pip install jaxpm jax-cosmo jaxopt\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# flip simulation submodule\n",
+    "from flip.simulation.generator import ForwardModel, get_cosmology\n",
+    "from flip.simulation.painter import (\n",
+    "    sky_to_cartesian,\n",
+    "    cartesian_to_box_frame,\n",
+    "    compute_los_velocity,\n",
+    "    interpolate_velocity_to_positions,\n",
+    ")\n",
+    "from flip.simulation.likelihood import VelocityFieldLikelihood, log_likelihood_gaussian\n",
+    "\n",
+    "print('JAX version:', jax.__version__)\n",
+    "print('devices:', jax.devices())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Cosmology and ForwardModel setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fiducial cosmology\n",
+    "cosmo = get_cosmology(omega_m=0.3, sigma8=0.8, h=0.6774)\n",
+    "print(cosmo)\n",
+    "\n",
+    "# Simulation box: 256 Mpc/h per side, 64^3 mesh → 4 Mpc/h cells\n",
+    "# (use 32^3 for fast testing)\n",
+    "MESH = (32, 32, 32)\n",
+    "BOX  = (256., 256., 256.)\n",
+    "\n",
+    "model = ForwardModel(\n",
+    "    mesh_shape=MESH,\n",
+    "    box_size=BOX,\n",
+    "    a_final=1.0,   # z = 0\n",
+    "    lpt_only=True, # Zel'dovich approximation — fast and differentiable\n",
+    ")\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Generate density and velocity fields"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seed = jax.random.PRNGKey(0)\n",
+    "\n",
+    "density_field, velocity_field = model.get_fields(cosmo, seed=seed)\n",
+    "\n",
+    "print(f'density_field shape: {density_field.shape}')\n",
+    "print(f'velocity_field shape: {velocity_field.shape}')\n",
+    "print(f'δ mean = {float(jnp.mean(density_field)):.4f}  (should be ≈ 0)')\n",
+    "print(f'δ std  = {float(jnp.std(density_field)):.4f}')\n",
+    "print(f'v rms  = {float(jnp.sqrt(jnp.mean(velocity_field**2))):.1f} km/s')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
+    "\n",
+    "# Density slice\n",
+    "ax = axes[0]\n",
+    "im = ax.imshow(np.array(density_field[:, :, MESH[2]//2]), origin='lower',\n",
+    "               cmap='RdBu_r', vmin=-2, vmax=2)\n",
+    "plt.colorbar(im, ax=ax, label=r'$\\delta$')\n",
+    "ax.set_title('Density contrast δ (z-slice)')\n",
+    "\n",
+    "# Velocity slices (x and y components)\n",
+    "for i, (ax, label) in enumerate(zip(axes[1:], [r'$v_x$ [km/s]', r'$v_y$ [km/s]'])):\n",
+    "    vmax = float(jnp.std(velocity_field[..., i])) * 2\n",
+    "    im = ax.imshow(np.array(velocity_field[:, :, MESH[2]//2, i]),\n",
+    "                   origin='lower', cmap='RdBu_r', vmin=-vmax, vmax=vmax)\n",
+    "    plt.colorbar(im, ax=ax, label=label)\n",
+    "    ax.set_title(f'Velocity {label} (z-slice)')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Extract LOS velocities at galaxy positions\n",
+    "\n",
+    "We create a mock galaxy catalog with RA/Dec/r_com and extract the simulated\n",
+    "line-of-sight peculiar velocity at each galaxy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(42)\n",
+    "N_gal = 200\n",
+    "\n",
+    "# Mock galaxy catalog: RA/Dec in radians, r_com in Mpc/h\n",
+    "ra   = jnp.array(rng.uniform(0,   2*np.pi, N_gal))  # radians\n",
+    "dec  = jnp.array(rng.uniform(-0.3, 0.3,   N_gal))   # radians (small survey)\n",
+    "rcom = jnp.array(rng.uniform(50,   110.,  N_gal))    # Mpc/h\n",
+    "\n",
+    "# Convert to Cartesian (observer at origin)\n",
+    "xyz_observer = sky_to_cartesian(ra, dec, rcom)\n",
+    "\n",
+    "# Shift to box frame (observer at box centre)\n",
+    "xyz_box = cartesian_to_box_frame(xyz_observer, BOX)\n",
+    "\n",
+    "print(f'Galaxy positions range (box frame):')\n",
+    "for i, ax in enumerate('xyz'):\n",
+    "    print(f'  {ax}: [{float(xyz_box[:,i].min()):.1f}, {float(xyz_box[:,i].max()):.1f}] Mpc/h')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Interpolate 3D velocity to galaxy positions\n",
+    "v3d_gal = interpolate_velocity_to_positions(velocity_field, xyz_box, BOX, MESH)\n",
+    "\n",
+    "# Project onto LOS (r̂ from observer-centred positions)\n",
+    "v_los = compute_los_velocity(v3d_gal, xyz_observer)\n",
+    "\n",
+    "print(f'v_los: mean={float(jnp.mean(v_los)):.1f}, std={float(jnp.std(v_los)):.1f} km/s')\n",
+    "\n",
+    "plt.figure(figsize=(7, 4))\n",
+    "plt.hist(np.array(v_los), bins=30, edgecolor='k', color='steelblue', alpha=0.8)\n",
+    "plt.xlabel('$v_{\\\\rm los}$ [km/s]')\n",
+    "plt.ylabel('Count')\n",
+    "plt.title('Simulated LOS peculiar velocities')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Gaussian field-level likelihood"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Observed velocities: use simulated + noise\n",
+    "sigma_obs = 150.0  # km/s measurement error\n",
+    "v_obs = np.array(v_los) + rng.normal(0, sigma_obs, N_gal)\n",
+    "var_obs = jnp.ones(N_gal) * sigma_obs**2\n",
+    "\n",
+    "ll = log_likelihood_gaussian(v_los, jnp.array(v_obs), var_obs)\n",
+    "print(f'log L = {float(ll):.2f}')\n",
+    "\n",
+    "# Likelihood is higher at the truth than at shifted velocity\n",
+    "ll_shifted = log_likelihood_gaussian(v_los + 200.0, jnp.array(v_obs), var_obs)\n",
+    "print(f'log L (200 km/s offset) = {float(ll_shifted):.2f}  (should be lower)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Gradients through the full pipeline\n",
+    "\n",
+    "The entire chain — from cosmological parameters through LPT simulation to the\n",
+    "likelihood — is differentiable via JAX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MockDataVector:\n",
+    "    \"\"\"Minimal stub: returns the observed velocities and variances.\"\"\"\n",
+    "    def __init__(self, v_obs, var_obs):\n",
+    "        self._v = v_obs\n",
+    "        self._var = var_obs\n",
+    "    def give_data_and_variance(self, params=None):\n",
+    "        return self._v, np.array(self._var)\n",
+    "\n",
+    "lik = VelocityFieldLikelihood(\n",
+    "    forward_model=model,\n",
+    "    data_vector=MockDataVector(v_obs, var_obs),\n",
+    "    positions_cartesian=xyz_box,\n",
+    "    seed=seed,\n",
+    ")\n",
+    "\n",
+    "# Evaluate at fiducial cosmology\n",
+    "params_fid = {\"omega_m\": 0.3, \"sigma8\": 0.8}\n",
+    "neg_ll = lik(params_fid)\n",
+    "print(f'-log L (fiducial) = {float(neg_ll):.2f}')\n",
+    "\n",
+    "# Gradient w.r.t. sigma8\n",
+    "def loss_sigma8(s8):\n",
+    "    return lik({\"omega_m\": 0.3, \"sigma8\": s8})\n",
+    "\n",
+    "g_s8 = jax.grad(loss_sigma8)(0.8)\n",
+    "print(f'd(-log L)/d(sigma8) = {float(g_s8):.4f}')\n",
+    "\n",
+    "# Gradient w.r.t. omega_m\n",
+    "def loss_omm(omm):\n",
+    "    return lik({\"omega_m\": omm, \"sigma8\": 0.8})\n",
+    "\n",
+    "g_omm = jax.grad(loss_omm)(0.3)\n",
+    "print(f'd(-log L)/d(omega_m) = {float(g_omm):.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Likelihood as a function of σ₈\n",
+    "\n",
+    "Scan the likelihood over σ₈ to check it peaks near the truth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigma8_grid = np.linspace(0.5, 1.2, 15)\n",
+    "neg_ll_grid = [float(lik({\"omega_m\": 0.3, \"sigma8\": s8})) for s8 in sigma8_grid]\n",
+    "\n",
+    "plt.figure(figsize=(7, 4))\n",
+    "plt.plot(sigma8_grid, neg_ll_grid, 'o-', color='steelblue')\n",
+    "plt.axvline(0.8, color='red', ls='--', label='truth σ₈=0.8')\n",
+    "plt.xlabel(r'$\\sigma_8$')\n",
+    "plt.ylabel(r'$-\\log\\mathcal{L}$')\n",
+    "plt.title('Likelihood scan over σ₈')\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. (Optional) Gradient-based optimization with SimulationFitter\n",
+    "\n",
+    "Requires `jaxopt`. Comment out or skip if not installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from flip.simulation.fitter import SimulationFitter\n",
+    "\n",
+    "    fitter = SimulationFitter(\n",
+    "        likelihood=lik,\n",
+    "        initial_params={\"omega_m\": 0.25, \"sigma8\": 0.70},\n",
+    "        bounds=(\n",
+    "            {\"omega_m\": 0.1, \"sigma8\": 0.3},\n",
+    "            {\"omega_m\": 0.9, \"sigma8\": 1.5},\n",
+    "        ),\n",
+    "        solver=\"LBFGSB\",\n",
+    "        maxiter=50,\n",
+    "    )\n",
+    "\n",
+    "    best = fitter.run()\n",
+    "    print('Best-fit parameters:')\n",
+    "    for k, v in best.items():\n",
+    "        print(f'  {k} = {v:.4f}')\n",
+    "\n",
+    "except ImportError:\n",
+    "    print('jaxopt not installed — skipping SimulationFitter demo.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. ForwardModel.from_survey_geometry\n",
+    "\n",
+    "Convenience constructor that sizes the box to a given survey."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Typical PV survey: r_max ~ 300 Mpc/h, cell size 5 Mpc/h\n",
+    "model_survey = ForwardModel.from_survey_geometry(\n",
+    "    rcom_max=300.0,\n",
+    "    cell_size_mpc=5.0,\n",
+    "    z_survey=0.05,\n",
+    "    lpt_only=True,\n",
+    ")\n",
+    "print(model_survey)\n",
+    "print(f'N_part = {model_survey.mesh_shape[0]**3:,}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -1,0 +1,316 @@
+"""Tests for flip.simulation — forward modeling via JaxPM.
+
+Covers:
+  - Field shapes and value ranges from ForwardModel.get_fields
+  - CIC interpolation correctness (_cic_read)
+  - LOS velocity projection
+  - Sky ↔ Cartesian coordinate conversion
+  - Gaussian log-likelihood sign and shape
+  - Gradient flow: jax.grad through the full pipeline (sigma8 → fields)
+  - VelocityFieldLikelihood evaluation
+  - ForwardModel.from_survey_geometry constructor
+
+All tests use a tiny mesh (16³) to keep wall-clock time short.
+"""
+
+import pytest
+
+pytest.importorskip("jaxpm", reason="jaxpm not installed")
+pytest.importorskip("jax_cosmo", reason="jax_cosmo not installed")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from flip.simulation.generator import ForwardModel, _run_lpt, get_cosmology
+from flip.simulation.likelihood import VelocityFieldLikelihood, log_likelihood_gaussian
+from flip.simulation.painter import (
+    _cic_read,
+    cartesian_to_box_frame,
+    compute_los_velocity,
+    interpolate_velocity_to_positions,
+    sky_to_cartesian,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+MESH = (16, 16, 16)
+BOX = (256.0, 256.0, 256.0)
+SEED = jax.random.PRNGKey(42)
+
+
+@pytest.fixture(scope="module")
+def cosmo():
+    return get_cosmology(omega_m=0.3, sigma8=0.8)
+
+
+@pytest.fixture(scope="module")
+def model():
+    return ForwardModel(mesh_shape=MESH, box_size=BOX, a_final=1.0, lpt_only=True)
+
+
+@pytest.fixture(scope="module")
+def fields(model, cosmo):
+    return model.get_fields(cosmo, seed=SEED)
+
+
+# ---------------------------------------------------------------------------
+# Generator tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_cosmology_attributes():
+    cosmo = get_cosmology(omega_m=0.3, sigma8=0.8)
+    assert hasattr(cosmo, "sigma8")
+    assert hasattr(cosmo, "Omega_c")
+    # Omega_c should be Omega_m - Omega_b
+    np.testing.assert_allclose(float(cosmo.Omega_c) + float(cosmo.Omega_b), 0.3, atol=1e-5)
+
+
+def test_density_field_shape(fields):
+    density, _ = fields
+    assert density.shape == MESH
+
+
+def test_velocity_field_shape(fields):
+    _, velocity = fields
+    assert velocity.shape == (*MESH, 3)
+
+
+def test_density_field_mean_near_zero(fields):
+    """Mean of density contrast should be close to zero (by definition of δ)."""
+    density, _ = fields
+    assert abs(float(jnp.mean(density))) < 0.5
+
+
+def test_velocity_field_finite(fields):
+    _, velocity = fields
+    assert jnp.all(jnp.isfinite(velocity))
+
+
+def test_density_field_finite(fields):
+    density, _ = fields
+    assert jnp.all(jnp.isfinite(density))
+
+
+def test_velocity_magnitude_reasonable(fields):
+    """Typical peculiar velocities at z=0 should be O(100–1000) km/s."""
+    _, velocity = fields
+    rms = float(jnp.sqrt(jnp.mean(velocity**2)))
+    assert 10.0 < rms < 5000.0, f"Unexpected RMS velocity: {rms:.1f} km/s"
+
+
+def test_reproducibility(model, cosmo):
+    """Same seed must produce identical fields."""
+    d1, v1 = model.get_fields(cosmo, seed=SEED)
+    d2, v2 = model.get_fields(cosmo, seed=SEED)
+    np.testing.assert_array_equal(np.array(d1), np.array(d2))
+    np.testing.assert_array_equal(np.array(v1), np.array(v2))
+
+
+def test_different_seeds_differ(model, cosmo):
+    """Different seeds must produce different fields."""
+    d1, _ = model.get_fields(cosmo, seed=jax.random.PRNGKey(0))
+    d2, _ = model.get_fields(cosmo, seed=jax.random.PRNGKey(1))
+    assert not jnp.allclose(d1, d2), "Fields with different seeds should differ"
+
+
+def test_sigma8_increases_amplitude(cosmo):
+    """Higher σ₈ should produce a larger density contrast variance."""
+    model = ForwardModel(mesh_shape=MESH, box_size=BOX, lpt_only=True)
+    cosmo_lo = get_cosmology(omega_m=0.3, sigma8=0.6)
+    cosmo_hi = get_cosmology(omega_m=0.3, sigma8=1.2)
+    d_lo, _ = model.get_fields(cosmo_lo, seed=SEED)
+    d_hi, _ = model.get_fields(cosmo_hi, seed=SEED)
+    assert float(jnp.std(d_hi)) > float(jnp.std(d_lo))
+
+
+def test_from_survey_geometry():
+    """ForwardModel.from_survey_geometry returns a valid instance."""
+    model = ForwardModel.from_survey_geometry(
+        rcom_max=200.0, cell_size_mpc=10.0, z_survey=0.05
+    )
+    assert len(model.mesh_shape) == 3
+    assert all(n > 0 for n in model.mesh_shape)
+    assert model.a_final == pytest.approx(1.0 / 1.05, rel=1e-4)
+
+
+def test_integer_seed(model, cosmo):
+    """ForwardModel should accept plain integer seeds."""
+    d, v = model.get_fields(cosmo, seed=0)
+    assert d.shape == MESH
+
+
+# ---------------------------------------------------------------------------
+# Gradient tests
+# ---------------------------------------------------------------------------
+
+
+def test_grad_sigma8(model):
+    """jax.grad w.r.t. sigma8 should be finite and non-zero."""
+    def loss(sigma8):
+        c = get_cosmology(omega_m=0.3, sigma8=sigma8)
+        d, _ = model.get_fields(c, seed=SEED)
+        return jnp.mean(d**2)
+
+    g = jax.grad(loss)(0.8)
+    assert jnp.isfinite(g), f"Gradient w.r.t. sigma8 is not finite: {g}"
+    assert abs(float(g)) > 0.0, "Gradient w.r.t. sigma8 should be non-zero"
+
+
+def test_grad_omega_m(model):
+    """jax.grad w.r.t. omega_m should be finite."""
+    def loss(omega_m):
+        c = get_cosmology(omega_m=omega_m, sigma8=0.8)
+        _, v = model.get_fields(c, seed=SEED)
+        return jnp.mean(v**2)
+
+    g = jax.grad(loss)(0.3)
+    assert jnp.isfinite(g), f"Gradient w.r.t. omega_m is not finite: {g}"
+
+
+# ---------------------------------------------------------------------------
+# Painter tests
+# ---------------------------------------------------------------------------
+
+
+def test_cic_read_grid_points():
+    """CIC at exact cell centres should return the cell value."""
+    Nx, Ny, Nz = 8, 8, 8
+    grid = jnp.arange(Nx * Ny * Nz, dtype=jnp.float32).reshape(Nx, Ny, Nz)
+    # Query at integer positions (cell centres)
+    pos = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 2.0, 3.0]])
+    vals = _cic_read(grid, pos)
+    expected = jnp.array([grid[0, 0, 0], grid[1, 0, 0], grid[0, 2, 3]])
+    np.testing.assert_allclose(np.array(vals), np.array(expected), atol=1e-5)
+
+
+def test_cic_read_periodic():
+    """CIC should wrap periodically at box boundaries."""
+    grid = jnp.ones((8, 8, 8))
+    pos = jnp.array([[7.9, 0.0, 0.0]])  # near boundary
+    val = _cic_read(grid, pos)
+    np.testing.assert_allclose(float(val[0]), 1.0, atol=1e-5)
+
+
+def test_compute_los_velocity_radial():
+    """For a purely radial velocity, v_los = |v|."""
+    positions = jnp.array([[100.0, 0.0, 0.0], [0.0, 50.0, 0.0]])
+    velocities = jnp.array([[300.0, 0.0, 0.0], [0.0, -200.0, 0.0]])
+    v_los = compute_los_velocity(velocities, positions)
+    np.testing.assert_allclose(np.array(v_los), np.array([300.0, -200.0]), atol=1e-3)
+
+
+def test_compute_los_velocity_transverse_zero():
+    """Velocity perpendicular to LOS should give v_los ≈ 0."""
+    positions = jnp.array([[100.0, 0.0, 0.0]])
+    velocities = jnp.array([[0.0, 500.0, 0.0]])  # transverse to x-LOS
+    v_los = compute_los_velocity(velocities, positions)
+    np.testing.assert_allclose(float(v_los[0]), 0.0, atol=1e-3)
+
+
+def test_sky_to_cartesian_on_axis():
+    """RA=0, Dec=0 should give purely x-direction."""
+    ra = jnp.array([0.0])
+    dec = jnp.array([0.0])
+    r = jnp.array([100.0])
+    xyz = sky_to_cartesian(ra, dec, r)
+    np.testing.assert_allclose(float(xyz[0, 0]), 100.0, atol=1e-4)
+    np.testing.assert_allclose(float(xyz[0, 1]), 0.0, atol=1e-4)
+    np.testing.assert_allclose(float(xyz[0, 2]), 0.0, atol=1e-4)
+
+
+def test_cartesian_to_box_frame_default_center():
+    """Centering at box centre should shift by box/2."""
+    positions = jnp.array([[0.0, 0.0, 0.0]])
+    box = [256.0, 256.0, 256.0]
+    shifted = cartesian_to_box_frame(positions, box)
+    np.testing.assert_allclose(
+        np.array(shifted[0]), np.array([128.0, 128.0, 128.0]), atol=1e-4
+    )
+
+
+def test_interpolate_velocity_shape(fields):
+    _, velocity = fields
+    N_gal = 20
+    pos = jnp.ones((N_gal, 3)) * 100.0  # all inside box
+    v_gal = interpolate_velocity_to_positions(velocity, pos, BOX, MESH)
+    assert v_gal.shape == (N_gal, 3)
+
+
+# ---------------------------------------------------------------------------
+# Likelihood tests
+# ---------------------------------------------------------------------------
+
+
+def test_log_likelihood_gaussian_diagonal():
+    """Diagonal log-likelihood should be finite for matching arrays."""
+    v_sim = jnp.zeros(10)
+    v_obs = jnp.zeros(10)
+    var = jnp.ones(10)
+    ll = log_likelihood_gaussian(v_sim, v_obs, var)
+    assert jnp.isfinite(ll)
+
+
+def test_log_likelihood_gaussian_perfect_fit():
+    """Log-likelihood at perfect fit (residual=0) should be maximum."""
+    v = jnp.ones(5) * 100.0
+    var = jnp.ones(5) * 25.0
+    ll_perfect = log_likelihood_gaussian(v, v, var)
+    ll_shifted = log_likelihood_gaussian(v + 10.0, v, var)
+    assert float(ll_perfect) > float(ll_shifted)
+
+
+def test_log_likelihood_gaussian_full_covariance():
+    """Full (2D) covariance branch should return finite scalar."""
+    N = 5
+    v_sim = jnp.zeros(N)
+    v_obs = jnp.zeros(N)
+    C = jnp.eye(N) * 100.0
+    ll = log_likelihood_gaussian(v_sim, v_obs, C)
+    assert jnp.isfinite(ll)
+
+
+class _MockDataVector:
+    """Minimal stub data vector for likelihood tests."""
+    def give_data_and_variance(self, params=None):
+        N = 20
+        return np.random.default_rng(0).normal(0, 200, N), np.ones(N) * 200.0**2
+
+
+def test_velocity_field_likelihood_evaluates(model, cosmo):
+    """VelocityFieldLikelihood should return a finite scalar."""
+    N_gal = 20
+    rng = np.random.default_rng(1)
+    xyz = rng.uniform(10.0, 240.0, (N_gal, 3))
+
+    lik = VelocityFieldLikelihood(
+        forward_model=model,
+        data_vector=_MockDataVector(),
+        positions_cartesian=xyz,
+        seed=SEED,
+    )
+    neg_ll = lik({"omega_m": 0.3, "sigma8": 0.8})
+    assert jnp.isfinite(neg_ll), f"Likelihood returned non-finite value: {neg_ll}"
+
+
+def test_velocity_field_likelihood_gradient(model):
+    """jax.grad through VelocityFieldLikelihood w.r.t. sigma8 should be finite."""
+    N_gal = 20
+    rng = np.random.default_rng(2)
+    xyz = jnp.array(rng.uniform(10.0, 240.0, (N_gal, 3)))
+
+    lik = VelocityFieldLikelihood(
+        forward_model=model,
+        data_vector=_MockDataVector(),
+        positions_cartesian=xyz,
+        seed=SEED,
+    )
+
+    def loss(sigma8):
+        return lik({"omega_m": 0.3, "sigma8": sigma8})
+
+    g = jax.grad(loss)(0.8)
+    assert jnp.isfinite(g), f"Likelihood gradient w.r.t. sigma8 not finite: {g}"


### PR DESCRIPTION
Vibe coded structure
Will be improved to perform a full PM forward modeling of the data fields in flip.data_vector.
The idea is to potentially include all potential PV methods in flip. Might be extended with SBI.
